### PR TITLE
Resolve invalid header error for Creation when interacting with tusdotnet server

### DIFF
--- a/Tus.Net.Client/Tus.Net.Client.csproj
+++ b/Tus.Net.Client/Tus.Net.Client.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <PackageId>Tus.Net.Client</PackageId>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <Authors>Hossyposs</Authors>
         <PackageDescription>Lightweight wrapper for the TUS Protocol</PackageDescription>
         <RepositoryUrl>https://github.com/hossyposs/Tus.Net.Client</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>1.0.4</PackageVersion>
+        <PackageVersion>1.0.5</PackageVersion>
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 </Project>

--- a/Tus.Net.Client/TusProtocol.cs
+++ b/Tus.Net.Client/TusProtocol.cs
@@ -127,7 +127,7 @@ namespace Tus.Net.Client
                 metadataStrings.Add($"{k} {v}");
             }
 
-            requestMessage.Headers.Add(TusHeaders.UploadMetadata, string.Join(", ", metadataStrings.ToArray()).Trim());
+            requestMessage.Headers.Add(TusHeaders.UploadMetadata, string.Join(",", metadataStrings.ToArray()).Trim());
             requestMessage.Headers.Add(TusHeaders.TusResumable, this._tusVersion);
 
             HttpResponseMessage responseMessage = await client.SendAsync(requestMessage);


### PR DESCRIPTION
When interacting with a tusdotnet powered tus server with the Creation extension enabled and using the TusClient.CreateEndpointAsync function, the submitted `Upload-Metadata` header does not meet the specification and causes the server to return the error
```
Header Upload-Metadata: The Upload-Metadata request and response header MUST consist of one or more comma - separated key - value pairs. The key and value MUST be separated by a space.The key MUST NOT contain spaces and commas and MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST be Base64 encoded. All keys MUST be unique. The value MAY be empty. In these cases, the space, which would normally separate the key and the value, MAY be left out.
```

This change resolves this issue.